### PR TITLE
Removing spaces between IDs, because they result in error message (invalid parameter)

### DIFF
--- a/vfioselect/vfioselect
+++ b/vfioselect/vfioselect
@@ -89,7 +89,7 @@ makefile()
   for line in $(cat $tmpfile); do
     printf "${lspciid[$line]}," >> $genfile
   done
-  truncate -s-2 $genfile #Fix trailing comma
+  truncate -s-1 $genfile #Fix trailing comma
   echo "$genfile written successfully."
 }
 

--- a/vfioselect/vfioselect
+++ b/vfioselect/vfioselect
@@ -87,7 +87,7 @@ makefile()
   printf "options vfio-pci ids=" >> $genfile
   IFS=" "
   for line in $(cat $tmpfile); do
-    printf "${lspciid[$line]}, " >> $genfile
+    printf "${lspciid[$line]}," >> $genfile
   done
   truncate -s-2 $genfile #Fix trailing comma
   echo "$genfile written successfully."


### PR DESCRIPTION
When using multiple IDs (a graphics card and it's dedicated HDMI audio device) everything after the first ID gets ignored. This can be seen when issuing `dmesg | grep vfio`.