### PR TITLE
Fixes hugepages.sh attempting to read sys device dir as file

### DIFF
--- a/libvirt_hooks/hooks/hugepages.sh
+++ b/libvirt_hooks/hooks/hugepages.sh
@@ -17,9 +17,9 @@ XML_PATH="/etc/libvirt/qemu/$GUEST_NAME.xml"
 # Get guest HugePage size
 HPG_SIZE=$(grep '<page size' "$XML_PATH" | grep -ohE '[[:digit:]]+')
 # Set path to HugePages
-HPG_PATH="/sys/devices/system/node/node0/hugepages"
+HPG_PATH="/sys/devices/system/node/node0/hugepages/hugepages-${HPG_SIZE}kB/nr_hugepages"
 # Get current number of HugePages
-HPG_CURRENT=$(cat "${HPG_PATH}/hugepages-${HPG_SIZE}kB/nr_hugepages")
+HPG_CURRENT=$(cat "${HPG_PATH}")
 # Get amount of memory used by the guest
 GUEST_MEM=$(grep '<memory unit' "$XML_PATH" | grep -ohE '[[:digit:]]+')
 
@@ -55,7 +55,7 @@ if [[ $HPG_SIZE -eq 0 ]]; then
 elif [[ -z $GUEST_MEM ]]; then
   echo "ERROR: Can't determine guest's memory allocation" >&2
   exit 1
-elif [[ ! -d "$HPG_PATH"  ]]; then
+elif [[ ! -f "$HPG_PATH"  ]]; then
   # Break if HugePages path doesn't exist
   echo "ERROR: ${HPG_PATH} does not exist. (HugePages disabled in kernel?)" >&2
   exit 1


### PR DESCRIPTION
In attempting to use this hook I discovered an error like this:
`/etc/libvirt/hooks/qemu.d/MYVM/prepare/begin/hugepages.sh: line 42: /sys/devices/system/node/node0/hugepages: Is a directory`

This PR corrects the error and restores expected functionality. Assuming this was working before, it seems likely this could be a change for newer kernels supporting different hugepage sizes.