### PR TITLE
switch shebang to use environment bash

### DIFF
--- a/libvirt_hooks/hooks/better_hugepages.sh
+++ b/libvirt_hooks/hooks/better_hugepages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author: SharkWipf (https://github.com/SharkWipf)
 #

--- a/libvirt_hooks/hooks/hugepages.sh
+++ b/libvirt_hooks/hooks/hugepages.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #
 # Author: Stefsinn (https://github.com/Stefsinn)
 #

--- a/libvirt_hooks/hooks/switch_displays.sh
+++ b/libvirt_hooks/hooks/switch_displays.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author: Sebastiaan Meijer (sebastiaan@passthroughpo.st)
 #

--- a/libvirt_hooks/qemu
+++ b/libvirt_hooks/qemu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Author: Sebastiaan Meijer (sebastiaan@passthroughpo.st)
 #

--- a/vfioselect/vfioselect
+++ b/vfioselect/vfioselect
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script to bind the VFIO stub driver to PCI devices
 # By Trent Arcuri, 2017
 #


### PR DESCRIPTION
Some distros such as NixOS don't have `/bin/bash`
Not all scripts in repo are using the env var bash shebang
This just switches the older scripts to use  the `#!/usr/bin/env bash`

