### PR TITLE
fix qemu script to run a single $HOOKPATH file

### DIFF
--- a/libvirt_hooks/qemu
+++ b/libvirt_hooks/qemu
@@ -21,7 +21,7 @@ HOOKPATH="$BASEDIR/qemu.d/$GUEST_NAME/$HOOK_NAME/$STATE_NAME"
 set -e # If a script exits with an error, we should as well.
 
 # check if it's a non-empty executable file
-if [ -f "$HOOKPATH" ] && [ -s "$HOOKPATH"] && [ -x "$HOOKPATH" ]; then
+if [ -f "$HOOKPATH" ] && [ -s "$HOOKPATH" ] && [ -x "$HOOKPATH" ]; then
     eval \"$HOOKPATH\" "$@"
 elif [ -d "$HOOKPATH" ]; then
     while read file; do


### PR DESCRIPTION
A missing space typo prevented detecting presence and validity of a single file at `$HOOKPATH`.